### PR TITLE
[CAMERA.LA.2.0.r1] Kbuild: Replace current folder with kernel source symlink

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 CAMERA_KERNEL_ROOT = $(srctree)/techpack/camera
+KERNEL_ROOT = $(srctree)
 
 ifeq ($(CONFIG_QCOM_CAMERA_DEBUG), y)
 $(info "CAMERA_KERNEL_ROOT is: $(CAMERA_KERNEL_ROOT)")

--- a/Kbuild
+++ b/Kbuild
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
-CAMERA_KERNEL_ROOT = $(shell pwd)/techpack/camera
+CAMERA_KERNEL_ROOT = $(srctree)/techpack/camera
 
 ifeq ($(CONFIG_QCOM_CAMERA_DEBUG), y)
 $(info "CAMERA_KERNEL_ROOT is: $(CAMERA_KERNEL_ROOT)")


### PR DESCRIPTION
We build kernel in a way where output folder contains the source
symlink. Thus we need to use the actual source for these files

Signed-off-by: Martin Botka <martin.botka@somainline.org>