### PR TITLE
[9.14] fix compilation

### DIFF
--- a/drivers/cam_ope/ope_hw_mgr/cam_ope_hw_mgr.c
+++ b/drivers/cam_ope/ope_hw_mgr/cam_ope_hw_mgr.c
@@ -3560,7 +3560,7 @@ static int cam_ope_mgr_hw_open_u(void *hw_priv, void *fw_download_args)
 	return rc;
 }
 
-static cam_ope_mgr_hw_close_u(void *hw_priv, void *hw_close_args)
+static int cam_ope_mgr_hw_close_u(void *hw_priv, void *hw_close_args)
 {
 	struct cam_ope_hw_mgr *hw_mgr;
 	int rc = 0;

--- a/drivers/cam_utils/cam_debug_util.c
+++ b/drivers/cam_utils/cam_debug_util.c
@@ -19,7 +19,7 @@ module_param(debug_type, uint, 0644);
 
 struct camera_debug_settings cam_debug;
 
-const struct camera_debug_settings *cam_debug_get_settings()
+const struct camera_debug_settings *cam_debug_get_settings(void)
 {
 	return &cam_debug;
 }


### PR DESCRIPTION
fix error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]