### PR TITLE
[9.16.r1] config: Mark Blair camera as a built-in

### DIFF
--- a/config/bengalcamera.conf
+++ b/config/bengalcamera.conf
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2019,2021 The Linux Foundation. All rights reserved.
 
-$(info "BENGAL SPECTRA_CAMERA IS MODULAR")
-export CONFIG_SPECTRA_CAMERA=m
-
-ifneq (,$(filter $(CONFIG_SPECTRA_CAMERA), y m))
+export CONFIG_SPECTRA_CAMERA=y
 export CONFIG_SPECTRA_TFE=y
 export CONFIG_SPECTRA_ISP=y
 export CONFIG_SPECTRA_SENSOR=y
 export CONFIG_SPECTRA_OPE=y
-endif

--- a/config/blaircamera.conf
+++ b/config/blaircamera.conf
@@ -1,17 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2021, The Linux Foundation. All rights reserved.
 
-ifeq ($(CONFIG_QGKI),y)
-export CONFIG_SPECTRA_CAMERA=m
-$(info "SPECTRA_CAMERA IS STATIC")
-else
-$(info "SPECTRA_CAMERA IS MODULAR")
-export CONFIG_SPECTRA_CAMERA=m
-endif
-
-ifneq (,$(filter $(CONFIG_SPECTRA_CAMERA), y m))
+export CONFIG_SPECTRA_CAMERA=y
 export CONFIG_SPECTRA_ISP=y
 export CONFIG_SPECTRA_OPE=y
 export CONFIG_SPECTRA_TFE=y
 export CONFIG_SPECTRA_SENSOR=y
-endif

--- a/config/sm6150camera.conf
+++ b/config/sm6150camera.conf
@@ -1,18 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2021, The Linux Foundation. All rights reserved.
 
-ifeq ($(CONFIG_QGKI),y)
-export CONFIG_SPECTRA_CAMERA=m
-$(info "QGKI Spectra Camera Building as DLKM")
-else
-export CONFIG_SPECTRA_CAMERA=m
-$(info "GKI Spectra Camera Building as DLKM")
-endif
-
-ifneq (,$(filter $(CONFIG_SPECTRA_CAMERA), y m))
+export CONFIG_SPECTRA_CAMERA=y
 export CONFIG_SPECTRA_ISP=y
 export CONFIG_SPECTRA_SENSOR=y
 export CONFIG_SPECTRA_ICP=y
 export CONFIG_SPECTRA_JPEG=y
 export CONFIG_SPECTRA_CUSTOM=y
-endif

--- a/drivers/cam_ope/ope_hw_mgr/ope_hw/ope_dev.c
+++ b/drivers/cam_ope/ope_hw_mgr/ope_hw/ope_dev.c
@@ -23,7 +23,7 @@
 
 static struct cam_ope_hw_intf_data cam_ope_dev_list[OPE_DEV_MAX];
 static struct cam_ope_device_hw_info ope_hw_info;
-static struct cam_ope_soc_private ope_soc_info;
+struct cam_ope_soc_private ope_soc_info;
 EXPORT_SYMBOL(ope_soc_info);
 
 static struct hw_version_reg ope_hw_version_reg = {


### PR DESCRIPTION
This change is to make Blair camera driver built-in.
Completes https://github.com/sonyxperiadev/kernel-techpack-camera/commit/e1da794c60d59ee7c8ea077c5dd52fe80aa339b0